### PR TITLE
Set headers with Sinatra helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     rspec-mocks (2.6.0)
     sinatra (1.2.7)
       rack (~> 1.1)
-      tilt (< 2.0, >= 1.2.2)
+      tilt (>= 1.2.2, < 2.0)
     tilt (1.3.3)
     timecop (0.3.5)
 

--- a/lib/fistface.rb
+++ b/lib/fistface.rb
@@ -11,18 +11,18 @@ module Sinatra
       end
 
       app.get '/:font_face.css' do
-        headers['Content-Type'] = 'text/css'
+        content_type 'text/css'
         open("#{ENV['S3_URL']}/#{params[:font_face]}.css").read
       end
 
       app.get '/:directory/:font_face' do
-        headers['Content-Type'] = case params[:font_face]
-                                  when /\.ttf$/  then 'font/truetype'
-                                  when /\.otf$/  then 'font/opentype'
-                                  when /\.woff$/ then 'font/woff'
-                                  when /\.eot$/  then 'application/vnd.ms-fontobject'
-                                  when /\.svg$/  then 'image/svg+xml'
-                                  end
+        content_type case params[:font_face]
+                     when /\.ttf$/  then 'font/truetype'
+                     when /\.otf$/  then 'font/opentype'
+                     when /\.woff$/ then 'font/woff'
+                     when /\.eot$/  then 'application/vnd.ms-fontobject'
+                     when /\.svg$/  then 'image/svg+xml'
+                     end
         open("#{ENV['S3_URL']}/#{params[:directory]}/#{params[:font_face]}").read
       end
 

--- a/lib/fistface.rb
+++ b/lib/fistface.rb
@@ -6,11 +6,8 @@ module Sinatra
 
     def self.registered(app)
       app.before do
-        one_year_in_seconds = 31536000
-
-        headers 'Cache-Control'               => "public, max-age=#{one_year_in_seconds}",
-                'Expires'                     => (Time.now + one_year_in_seconds).httpdate,
-                'Access-Control-Allow-Origin' => '*'
+        expires 31536000, :public
+        headers 'Access-Control-Allow-Origin' => '*'
       end
 
       app.get '/:font_face.css' do

--- a/lib/fistface.rb
+++ b/lib/fistface.rb
@@ -17,11 +17,11 @@ module Sinatra
 
       app.get '/:directory/:font_face' do
         headers['Content-Type'] = case params[:font_face]
-                                    when /\.ttf$/  then 'font/truetype'
-                                    when /\.otf$/  then 'font/opentype'
-                                    when /\.woff$/ then 'font/woff'
-                                    when /\.eot$/  then 'application/vnd.ms-fontobject'
-                                    when /\.svg$/  then 'image/svg+xml'
+                                  when /\.ttf$/  then 'font/truetype'
+                                  when /\.otf$/  then 'font/opentype'
+                                  when /\.woff$/ then 'font/woff'
+                                  when /\.eot$/  then 'application/vnd.ms-fontobject'
+                                  when /\.svg$/  then 'image/svg+xml'
                                   end
         open("#{ENV['S3_URL']}/#{params[:directory]}/#{params[:font_face]}").read
       end

--- a/spec/fistface_spec.rb
+++ b/spec/fistface_spec.rb
@@ -25,7 +25,7 @@ describe "FistFace" do
     end
 
     it "is in the CSS Content-Type" do
-      last_response.content_type.should == 'text/css'
+      last_response.content_type.should == 'text/css;charset=utf-8'
     end
 
     it "wildcards the Access-Control-Allow-Origin header so Firefox can access the file" do


### PR DESCRIPTION
Less code! :smile: 

According to [docs](http://rubydoc.info/gems/sinatra/Sinatra/Helpers#expires-instance_method), `expires` sets both `Cache-Control` and `Expires`, taking just an integer argument.

[`content_type`](http://rubydoc.info/gems/sinatra/Sinatra/Helpers#content_type-instance_method) is a little cleaner too.
